### PR TITLE
fix: ios footer size (issue #10)

### DIFF
--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -18,6 +18,7 @@ import AnalyticsPage from './pages/AnalyticsPage';
 import NewProfilePage from './pages/NewProfilePage';
 import AchievementsPage from './pages/AchievementsPage';
 import CameraView from './components/CameraView';
+import { HEIGHT } from './constants/screenSize';
 
 const Stack = createStackNavigator();
 const Tab = createBottomTabNavigator();
@@ -94,7 +95,7 @@ function TabNavigator() {
       screenOptions={({ route }) => ({
         tabBarActiveTintColor: theme.colors.primary,
         tabBarInactiveTintColor: theme.colors.black,
-        tabBarStyle: { height: 64, borderTopWidth: 1 },
+        tabBarStyle: { height: HEIGHT * 0.1, borderTopWidth: 1 },
         tabBarIcon: ({ color }) => getIcon(route, color),
       })}
     >


### PR DESCRIPTION
# Description
Fix #10 
Made footer size 10% of the device height. This seems to look good on the following devices:
- iPhone 13
- Pixel 5
