### PR TITLE
Update units

### DIFF
--- a/__tests__/getConvertedUnits.test.ts
+++ b/__tests__/getConvertedUnits.test.ts
@@ -1,0 +1,86 @@
+import getConvertedUnits from '../src/util/getConvertedUnits';
+import { SettingsType } from '../src/globals/settings';
+import { Sport } from '../src/constants/units';
+import { it, expect } from '@jest/globals';
+
+const demoSettings: SettingsType = {
+  currentPlanet: 'earth',
+  units: {
+    golf: { speed: 'mph', distance: 'yards' },
+    baseball: { speed: 'kph', distance: 'meters' },
+    basketball: { speed: 'm/s', distance: 'feet' },
+    tennis: { speed: 'mph', distance: 'feet' },
+    soccer: { speed: 'mph', distance: 'feet' },
+  },
+  darkMode: false,
+  notificationsEnabled: true,
+  language: 'English',
+};
+
+// All of the following values were calculated using Google's unit converter
+it('converts speed to mph correctly', () => {
+  const converted = getConvertedUnits({
+    value: 1,
+    settings: demoSettings,
+    sport: 'golf' as Sport,
+    unitType: 'speed',
+  });
+
+  expect(converted).toEqual({ value: 2.23694, unit: 'mph' });
+});
+
+it('converts speed to kph correctly', () => {
+  const converted = getConvertedUnits({
+    value: 1,
+    settings: demoSettings,
+    sport: 'baseball' as Sport,
+    unitType: 'speed',
+  });
+
+  expect(converted).toEqual({ value: 3.6, unit: 'kph' });
+});
+
+it('converts speed to m/s correctly', () => {
+  const converted = getConvertedUnits({
+    value: 1,
+    settings: demoSettings,
+    sport: 'basketball' as Sport,
+    unitType: 'speed',
+  });
+
+  expect(converted).toEqual({ value: 1, unit: 'm/s' });
+});
+
+// Distance tests
+it('converts distance to yards correctly', () => {
+  const converted = getConvertedUnits({
+    value: 1,
+    settings: demoSettings,
+    sport: 'golf' as Sport,
+    unitType: 'distance',
+  });
+
+  expect(converted).toEqual({ value: 1.09361, unit: 'yards' });
+});
+
+it('converts distance to meters correctly', () => {
+  const converted = getConvertedUnits({
+    value: 1,
+    settings: demoSettings,
+    sport: 'baseball' as Sport,
+    unitType: 'distance',
+  });
+
+  expect(converted).toEqual({ value: 1, unit: 'meters' });
+});
+
+it('converts distance to feet correctly', () => {
+  const converted = getConvertedUnits({
+    value: 1,
+    settings: demoSettings,
+    sport: 'basketball' as Sport,
+    unitType: 'distance',
+  });
+
+  expect(converted).toEqual({ value: 3.28084, unit: 'feet' });
+});

--- a/sampleData/previousRuns.ts
+++ b/sampleData/previousRuns.ts
@@ -1,4 +1,4 @@
-// @ts-ignore
+// All values for 'speed' and 'distance' are saved in 'm/s' and 'm' respectively
 export const previousRuns: Activity[] = [
   {
     id: '0',
@@ -6,6 +6,7 @@ export const previousRuns: Activity[] = [
     speed: 5,
     username: 'Jordan',
     videoUri: '3.mp4',
+    sport: 'baseball',
   },
   {
     id: '1',
@@ -13,6 +14,7 @@ export const previousRuns: Activity[] = [
     speed: 5.5,
     username: 'Jordan',
     videoUri: '2.mp4',
+    sport: 'baseball',
   },
   {
     id: '2',
@@ -20,5 +22,6 @@ export const previousRuns: Activity[] = [
     speed: 5.5,
     username: 'Jordan',
     videoUri: '1.mp4',
+    sport: 'baseball',
   },
 ];

--- a/src/pages/PreviousRunsPage.tsx
+++ b/src/pages/PreviousRunsPage.tsx
@@ -3,20 +3,37 @@ import Page from '../components/Page';
 import { previousRuns } from '../../sampleData/previousRuns';
 import BaseText from '../components/BaseText';
 import theme from '../globals/globalStyles';
+import { formatDate } from '../util/formatDate';
+import { SettingsContext } from '../../App';
+import { useContext } from 'react';
+import getConvertedUnits from '../util/getConvertedUnits';
+import { Sport } from '../constants/units';
 
 export default function PreviousRunsPage() {
+  const { settings } = useContext(SettingsContext);
+
+  const getValue = (run: Activity) => {
+    const { value, unit } = getConvertedUnits({
+      value: run.speed,
+      settings,
+      sport: run.sport,
+      unitType: 'speed', // TODO: Add distance
+    });
+
+    return `${value.toFixed(1)} ${unit}`;
+  };
+
   return (
     <Page>
       <ScrollView>
-        {previousRuns.map((run) => {
-          return (
-            <View key={run.id} style={styles.run}>
-              <BaseText>{run.username}</BaseText>
-              <BaseText>{run.speed}</BaseText>
-              <BaseText>{run.date}</BaseText>
-            </View>
-          );
-        })}
+        {previousRuns.map((run) => (
+          <View key={run.id} style={styles.run}>
+            <BaseText>{run.username}</BaseText>
+            <BaseText>{run.sport}</BaseText>
+            <BaseText>{getValue(run)}</BaseText>
+            <BaseText>{formatDate(run.date)}</BaseText>
+          </View>
+        ))}
       </ScrollView>
     </Page>
   );

--- a/src/util/getConvertedUnits.ts
+++ b/src/util/getConvertedUnits.ts
@@ -1,0 +1,48 @@
+import { Distance, Speed, Sport, Unit, UnitEnum } from '../constants/units';
+import { SettingsType } from '../globals/settings';
+
+type Props = {
+  value: number;
+  settings: SettingsType;
+  sport: Sport;
+  unitType: UnitEnum;
+};
+
+export default function getConvertedUnits({
+  value,
+  settings,
+  sport,
+  unitType,
+}: Props) {
+  const { units } = settings;
+
+  // Convert from meters per second
+  const speedFactorMap: Record<Speed, number> = {
+    mph: 2.23694,
+    kph: 3.6,
+    'm/s': 1,
+  };
+
+  // Convert from meters
+  const distanceFactorMap: Record<Distance, number> = {
+    yards: 1.09361,
+    meters: 1,
+    feet: 3.28084,
+  };
+
+  // Speed
+  if (unitType === 'speed') {
+    const targetUnit = units[sport][unitType] as Speed;
+    return {
+      value: value * speedFactorMap[targetUnit],
+      unit: targetUnit,
+    };
+  }
+
+  // Distance
+  const targetUnit = units[sport][unitType] as Distance;
+  return {
+    value: value * distanceFactorMap[targetUnit],
+    unit: targetUnit,
+  };
+}

--- a/src/util/getConvertedUnits.ts
+++ b/src/util/getConvertedUnits.ts
@@ -1,6 +1,13 @@
 import { Distance, Speed, Sport, Unit, UnitEnum } from '../constants/units';
 import { SettingsType } from '../globals/settings';
 
+/*
+ * value: number - the value to convert
+ * settings: SettingsType - the user's settings
+ * sport: Sport - the sport to convert for (e.g. 'baseball')
+ * unitType: UnitEnum - the type of unit to convert ('speed' or 'distance')
+ */
+
 type Props = {
   value: number;
   settings: SettingsType;

--- a/types.ts
+++ b/types.ts
@@ -1,3 +1,5 @@
+import { Sport } from './src/constants/units';
+
 export {}; // needed to make this a module
 
 declare global {
@@ -7,6 +9,7 @@ declare global {
     speed: number;
     username: string;
     videoUri: string;
+    sport: Sport;
   };
 
   type AchievementType = {


### PR DESCRIPTION
# Description

Created `getConvertedUnits` function with the following props:
- value: number -The value you want to convert (Always measured as meters or meters per second)
- settings: SettingsType -The current user's settings
- sport: Sport -The sport to convert for
- unitType: UnitEnum -The type of unit to convert (speed | distance)

Using the user's settings, this function converts from meters to the appropriate unit for whichever particular sport the run was made on.

For example, a user could have their speed setting for golf as m/s, while their speed setting for baseball may be km/h.

The FactorMap values (and test case values) were obtained through Google's built in Unit converter.
[More information here](https://support.google.com/websearch/answer/3284611?hl=en-CA#unitconverter)

Additional changes:
- Added SportType property to the Activity type
- Added sport display in `PreviousRunsPage`

> **_NOTE:_**  Currently the text for the value in `PreviousRunsPage` are rounded to 1 decimal place.
